### PR TITLE
Add "insert repeat" feature

### DIFF
--- a/kaka-core/src/history.rs
+++ b/kaka-core/src/history.rs
@@ -72,7 +72,7 @@ impl Commit {
             timestamp,
         };
 
-        log::debug!("Creating commit {commit:?}");
+        log::debug!("Creating commit {commit:#?}");
 
         commit
     }
@@ -92,7 +92,7 @@ mod test {
         for _ in 0..10 {
             history
                 .commits
-                .push(Commit::new(&Rope::new(), Transaction::new(&Rope::new())));
+                .push(Commit::new(&Rope::new(), Transaction::new(&Rope::new(), 0)));
         }
 
         history.head = 10;

--- a/kaka/src/client/crossterm_impl/canvas.rs
+++ b/kaka/src/client/crossterm_impl/canvas.rs
@@ -52,6 +52,7 @@ impl<T: Write> CrosstermCanvas<T> {
 
     fn setup_panic() {
         let hook = std::panic::take_hook();
+
         std::panic::set_hook(Box::new(move |info| {
             let mut stdout = stdout();
             stdout.execute(LeaveAlternateScreen).ok();
@@ -61,7 +62,6 @@ impl<T: Write> CrosstermCanvas<T> {
         }));
     }
 }
-
 
 impl<T: Write> Canvas for CrosstermCanvas<T> {
     fn clear(&mut self) -> Result<()> {
@@ -81,7 +81,7 @@ impl<T: Write> Canvas for CrosstermCanvas<T> {
         let mut modifier = Modifier::empty();
 
         for (point, cell) in cells {
-            if !matches!(prev_point, Some(p) if point.x == p.x +1 && point.y == p.y) {
+            if !matches!(prev_point, Some(p) if point.x == p.x + 1 && point.y == p.y) {
                 queue!(self.writer, MoveTo(point.x, point.y))?;
             }
 

--- a/kaka/src/client/surface.rs
+++ b/kaka/src/client/surface.rs
@@ -16,7 +16,6 @@ pub struct Cell {
 
 impl Cell {
     pub fn set_symbol(&mut self, sym: &str) -> &mut Self {
-
         self.symbol.clear();
         self.symbol.push_str(sym);
         self
@@ -118,8 +117,7 @@ impl Surface {
 
         let graphemes = UnicodeSegmentation::graphemes(string.as_ref(), true);
 
-        let max_offset =
-            (self.area.right() as usize).min(width.saturating_add(pos.x as usize)) as usize;
+        let max_offset = (self.area.right() as usize).min(width.saturating_add(pos.x as usize));
 
         for s in graphemes {
             let width = s.width();

--- a/kaka/src/editor/keymap.rs
+++ b/kaka/src/editor/keymap.rs
@@ -39,22 +39,6 @@ impl Keymap {
         self.0.get(&event)
     }
 
-    /// some input paths used for tests
-    pub fn xd() -> Self {
-        let mappings = [
-            ("q", command!(close)),
-            ("x", command!(print_a)),
-            ("i", command!(switch_to_insert_mode_before)),
-            ("a", command!(switch_to_insert_mode_after)),
-            ("gac", command!(print_a)),
-            ("gz", command!(print_a)),
-            ("<C-a>x", command!(print_a)),
-            ("<C-a><C-b>d", command!(print_a)),
-        ];
-
-        Self::with_mappings(mappings)
-    }
-
     pub fn insert_mode() -> Self {
         Self::with_mappings([("<ESC>", command!(switch_to_normal_mode))])
     }
@@ -74,7 +58,6 @@ impl Keymap {
             ("G", command!(goto_line_default_bottom)),
             ("u", command!(undo)),
             ("<C-r>", command!(redo)),
-            ("<Space>xd", command!(switch_to_xd_mode)),
             ("zs", command!(save)), // tmp
             ("ZZ", command!(close)),
             ("x", command!(remove_char)),
@@ -89,9 +72,7 @@ impl Keymap {
         Self::with_mappings(mappings)
     }
 
-    pub fn with_mappings(
-        mappings: impl IntoIterator<Item = (&'static str, Command)>,
-    ) -> Self {
+    pub fn with_mappings(mappings: impl IntoIterator<Item = (&'static str, Command)>) -> Self {
         let mut keymap = Self::default();
 
         let mut mappings = mappings
@@ -165,7 +146,7 @@ mod test {
 
     #[test]
     fn test_keymap() {
-        let keymap = Keymap::xd();
+        let keymap = Keymap::normal_mode();
         println!("Keymap {keymap:#?}");
     }
 }

--- a/kaka/src/editor/mod.rs
+++ b/kaka/src/editor/mod.rs
@@ -33,7 +33,6 @@ pub struct Editor {
 impl Editor {
     pub fn init() -> Self {
         let mut keymaps = Keymaps::default();
-        keymaps.register_keymap_for_mode(&Mode::Xd, Keymap::xd());
         keymaps.register_keymap_for_mode(&Mode::Insert, Keymap::insert_mode());
         keymaps.register_keymap_for_mode(&Mode::Normal, Keymap::normal_mode());
 

--- a/kaka/src/editor/mode.rs
+++ b/kaka/src/editor/mode.rs
@@ -1,34 +1,28 @@
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
     Normal,
     Insert,
     Xd,
-    #[allow(unused)]
-    Custom(Box<dyn CustomModeType>),
 }
 
 impl Mode {
-    #[allow(unused)]
-    pub fn custom<M: CustomModeType + 'static>(mode: M) -> Self {
-        Self::Custom(Box::new(mode))
-    }
-
     pub const fn is_insert(&self) -> bool {
         matches!(self, Self::Insert)
     }
 
-    pub fn name(&self) -> &str {
+    pub const fn name(&self) -> &str {
         match self {
             Self::Insert => "insert",
             Self::Normal => "normal",
             Self::Xd => "xd",
-            Self::Custom(c) => c.name(),
         }
     }
 }
 
-pub trait CustomModeType: Debug {
-    fn name(&self) -> &str;
+impl Display for Mode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
 }

--- a/kaka/src/editor/utils.rs
+++ b/kaka/src/editor/utils.rs
@@ -15,9 +15,9 @@ fn to_tokens(chars: &str) -> Result<Vec<Token<'_>>> {
     let mut tokens = vec![];
     let mut diamond_start = None;
 
-    let e = |ch, pos| anyhow::bail!("Unexpected char {ch} on pos {pos}");
-
     for (i, ch) in chars.chars().enumerate() {
+        let err = || anyhow::bail!("Unexpected char {ch} on pos {i}");
+
         if ch.is_ascii_whitespace() {
             break;
         }
@@ -26,9 +26,9 @@ fn to_tokens(chars: &str) -> Result<Vec<Token<'_>>> {
 
         match diamond_start {
             None if ch == '<' => diamond_start = Some(i),
-            None if ch == '>' => e(ch, i)?,
+            None if ch == '>' => err()?,
             None => tokens.push(Token::Char(ch)),
-            Some(_) if ch == '<' => e(ch, i)?,
+            Some(_) if ch == '<' => err()?,
             Some(start) if ch == '>' => {
                 tokens.push(Token::Diamond(&chars[start + 1..i]));
                 diamond_start = None;

--- a/kaka/src/main.rs
+++ b/kaka/src/main.rs
@@ -14,10 +14,9 @@ mod macros;
 use std::io::stdout;
 
 use app::App;
+pub use client::Canvas;
 use client::Client;
 use crossterm::event::EventStream;
-
-pub use client::Canvas;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
Allows for executing insert mode changes _n_ times,
Example: 123iabc<ESC>

+ Fix "moving backward" during transaction